### PR TITLE
Fix build_downgraded pipeline

### DIFF
--- a/.github/workflows/build_downgraded.yaml
+++ b/.github/workflows/build_downgraded.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Downgrade code for production (to PHP 7.1)
         run: |
-          composer install
+          composer install --no-blocking
           bin/rector process
       - name: Build project for production
         run: |


### PR DESCRIPTION
## Summary

- Add `--no-blocking` to `composer install` in `build_downgraded.yaml` to allow installing `guzzlehttp/guzzle ^6.3` despite Packagist security advisories

🤖 Generated with [Claude Code](https://claude.com/claude-code)